### PR TITLE
sys-libs/glibc: add guards for run_locale_gen in case of binary merge

### DIFF
--- a/sys-libs/glibc/glibc-2.29-r2.ebuild
+++ b/sys-libs/glibc/glibc-2.29-r2.ebuild
@@ -1140,8 +1140,13 @@ run_locale_gen() {
 		locale_list="${root}/usr/share/i18n/SUPPORTED"
 	fi
 
-	locale-gen --jobs $(makeopts_jobs) --config "${locale_list}" \
-		--destdir "${root}"
+	if [[ ${MERGE_TYPE} == "binary" ]] ; then
+		locale-gen --jobs $(makeopts_jobs) --config "${locale_list}" \
+			--destdir "${root}"
+	elif  [[ ${MERGE_TYPE} != "binary" ]] ; then
+		locale-gen --jobs 1 --config "${locale_list}" \
+			--destdir "${root}"
+	fi
 }
 
 glibc_do_src_install() {


### PR DESCRIPTION
closes: https://bugs.gentoo.org/680782

Signed-off-by: Steffen Kuhn <nielson2@yandex.com>