### PR TITLE
sys-devel/llvm: move dev-lang/perl to BDEPEND wrt #694460

### DIFF
--- a/sys-devel/llvm/llvm-10.0.0.9999.ebuild
+++ b/sys-devel/llvm/llvm-10.0.0.9999.ebuild
@@ -55,7 +55,6 @@ RDEPEND="
 	z3? ( >=sci-mathematics/z3-4.7.1:0=[${MULTILIB_USEDEP}] )"
 # configparser-3.2 breaks the build (3.3 or none at all are fine)
 DEPEND="${RDEPEND}
-	dev-lang/perl
 	|| ( >=sys-devel/gcc-3.0 >=sys-devel/llvm-3.5
 		( >=sys-freebsd/freebsd-lib-9.1-r10 sys-libs/libcxx )
 	)
@@ -75,6 +74,7 @@ DEPEND="${RDEPEND}
 # installed means llvm-config there will take precedence.
 RDEPEND="${RDEPEND}
 	!sys-devel/llvm:0"
+BDEPEND="dev-lang/perl"
 PDEPEND="sys-devel/llvm-common
 	gold? ( >=sys-devel/llvmgold-${SLOT} )"
 

--- a/sys-devel/llvm/llvm-9.0.0.9999.ebuild
+++ b/sys-devel/llvm/llvm-9.0.0.9999.ebuild
@@ -53,7 +53,6 @@ RDEPEND="
 	z3? ( >=sci-mathematics/z3-4.7.1:0=[${MULTILIB_USEDEP}] )"
 # configparser-3.2 breaks the build (3.3 or none at all are fine)
 DEPEND="${RDEPEND}
-	dev-lang/perl
 	|| ( >=sys-devel/gcc-3.0 >=sys-devel/llvm-3.5
 		( >=sys-freebsd/freebsd-lib-9.1-r10 sys-libs/libcxx )
 	)
@@ -73,6 +72,7 @@ DEPEND="${RDEPEND}
 # installed means llvm-config there will take precedence.
 RDEPEND="${RDEPEND}
 	!sys-devel/llvm:0"
+BDEPEND="dev-lang/perl"
 PDEPEND="sys-devel/llvm-common
 	gold? ( >=sys-devel/llvmgold-${SLOT} )"
 


### PR DESCRIPTION
dev-lang/perl is a build time dependency, but it must run by the host (CBUILD). Moving it to BDEPEND solves the issue of dev-lang/perl and friends getting pulled into the dependency graph. BDEPEND has been introduced in EAPI=7, so the fix is only possible for >=llvm-9.x