### PR TITLE
www-client/firefox and mail-client/thunderbird: reenable webrtc for arm

### DIFF
--- a/mail-client/thunderbird/thunderbird-68.0-r2.ebuild
+++ b/mail-client/thunderbird/thunderbird-68.0-r2.ebuild
@@ -544,9 +544,6 @@ src_configure() {
 
 	mozconfig_annotate '' --enable-extensions="${MEXTENSIONS}"
 
-	# disable webrtc for now, bug 667642
-	use arm && mozconfig_annotate 'broken on arm' --disable-webrtc
-
 	# allow elfhack to work in combination with unstripped binaries
 	# when they would normally be larger than 2GiB.
 	append-ldflags "-Wl,--compress-debug-sections=zlib"

--- a/mail-client/thunderbird/thunderbird-68.1.0.ebuild
+++ b/mail-client/thunderbird/thunderbird-68.1.0.ebuild
@@ -544,9 +544,6 @@ src_configure() {
 
 	mozconfig_annotate '' --enable-extensions="${MEXTENSIONS}"
 
-	# disable webrtc for now, bug 667642
-	use arm && mozconfig_annotate 'broken on arm' --disable-webrtc
-
 	# allow elfhack to work in combination with unstripped binaries
 	# when they would normally be larger than 2GiB.
 	append-ldflags "-Wl,--compress-debug-sections=zlib"

--- a/www-client/firefox/firefox-68.1.0.ebuild
+++ b/www-client/firefox/firefox-68.1.0.ebuild
@@ -544,9 +544,6 @@ src_configure() {
 
 	mozconfig_annotate '' --enable-extensions="${MEXTENSIONS}"
 
-	# disable webrtc for now, bug 667642
-	use arm && mozconfig_annotate 'broken on arm' --disable-webrtc
-
 	# allow elfhack to work in combination with unstripped binaries
 	# when they would normally be larger than 2GiB.
 	append-ldflags "-Wl,--compress-debug-sections=zlib"

--- a/www-client/firefox/firefox-69.0.ebuild
+++ b/www-client/firefox/firefox-69.0.ebuild
@@ -548,9 +548,6 @@ src_configure() {
 
 	mozconfig_annotate '' --enable-extensions="${MEXTENSIONS}"
 
-	# disable webrtc for now, bug 667642
-	use arm && mozconfig_annotate 'broken on arm' --disable-webrtc
-
 	# allow elfhack to work in combination with unstripped binaries
 	# when they would normally be larger than 2GiB.
 	append-ldflags "-Wl,--compress-debug-sections=zlib"


### PR DESCRIPTION
this has been broken for the longest time, starting with firefox-62 or earlier, and just happened to be fixed with the new firefox-68.0-esr release

Closes: https://bugs.gentoo.org/667642