### PR TITLE
sys-libs/libomp: move dev-lang/perl to BDEPEND wrt to #694582

### DIFF
--- a/sys-libs/libomp/libomp-10.0.0.9999.ebuild
+++ b/sys-libs/libomp/libomp-10.0.0.9999.ebuild
@@ -36,12 +36,12 @@ RDEPEND="
 # - sys-devel/llvm provide test utils (e.g. FileCheck)
 # - sys-devel/clang provides the compiler to run tests
 DEPEND="${RDEPEND}
-	dev-lang/perl
 	offload? ( virtual/pkgconfig[${MULTILIB_USEDEP}] )
 	test? (
 		$(python_gen_any_dep 'dev-python/lit[${PYTHON_USEDEP}]')
 		>=sys-devel/clang-6
 	)"
+BDEPEND="dev-lang/perl"
 
 # least intrusive of all
 CMAKE_BUILD_TYPE=RelWithDebInfo

--- a/sys-libs/libomp/libomp-9.0.0.9999.ebuild
+++ b/sys-libs/libomp/libomp-9.0.0.9999.ebuild
@@ -37,12 +37,12 @@ RDEPEND="
 # - sys-devel/llvm provide test utils (e.g. FileCheck)
 # - sys-devel/clang provides the compiler to run tests
 DEPEND="${RDEPEND}
-	dev-lang/perl
 	offload? ( virtual/pkgconfig[${MULTILIB_USEDEP}] )
 	test? (
 		$(python_gen_any_dep 'dev-python/lit[${PYTHON_USEDEP}]')
 		>=sys-devel/clang-6
 	)"
+BDEPEND="dev-lang/perl"
 
 # least intrusive of all
 CMAKE_BUILD_TYPE=RelWithDebInfo


### PR DESCRIPTION
dev-lang/perl is a build time dependency of libomp. Moving it to BDEPEND. 

Closes: https://bugs.gentoo.org/694582