### PR TITLE
www-client/firefox: split up neon and thumb

### DIFF
--- a/profiles/arch/arm/armv7a/package.use.force
+++ b/profiles/arch/arm/armv7a/package.use.force
@@ -1,0 +1,4 @@
+# allow users to choose if they want to have thumb on armv7a
+dev-lang/spidermonkey -cpu_flags_arm_thumb
+mail-client/thunderbird -cpu_flags_arm_thumb
+www-client/firefox -cpu_flags_arm_thumb

--- a/www-client/firefox/firefox-85.0.2-r1.ebuild
+++ b/www-client/firefox/firefox-85.0.2-r1.ebuild
@@ -778,8 +778,9 @@ src_configure() {
 		mozconfig_add_options_ac '+cpu_flags_arm_neon' --with-fpu=neon
 	fi
 	
-	if use cpu_flags_arm_thumb && if ! tc-is-clang ; then
+	if use cpu_flags_arm_thumb ; then
 		# thumb options aren't supported when using clang, bug 666966
+		# you will need additional rust-std thumbv7neon-unknown-linux-gnueabihf
 		mozconfig_add_options_ac '+cpu_flags_arm_thumb' \
 			--with-thumb=yes \
 			--with-thumb-interwork=no

--- a/www-client/firefox/firefox-85.0.2-r1.ebuild
+++ b/www-client/firefox/firefox-85.0.2-r1.ebuild
@@ -61,9 +61,9 @@ KEYWORDS="~amd64 ~arm64 ~ppc64 ~x86"
 
 SLOT="0/$(ver_cut 1)"
 LICENSE="MPL-2.0 GPL-2 LGPL-2.1"
-IUSE="+clang cpu_flags_arm_neon dbus debug eme-free geckodriver +gmp-autoupdate
-	hardened hwaccel jack lto +openh264 pgo pulseaudio screencast selinux
-	+system-av1 +system-harfbuzz +system-icu +system-jpeg +system-libevent
+IUSE="+clang cpu_flags_arm_neon cpu_flags_arm_thumb dbus debug eme-free geckodriver 
+	+gmp-autoupdate hardened hwaccel jack lto +openh264 pgo pulseaudio screencast 
+	selinux +system-av1 +system-harfbuzz +system-icu +system-jpeg +system-libevent
 	+system-libvpx +system-webp wayland wifi"
 
 REQUIRED_USE="debug? ( !system-av1 )
@@ -776,13 +776,13 @@ src_configure() {
 	# Modifications to better support ARM, bug #553364
 	if use cpu_flags_arm_neon ; then
 		mozconfig_add_options_ac '+cpu_flags_arm_neon' --with-fpu=neon
-
-		if ! tc-is-clang ; then
-			# thumb options aren't supported when using clang, bug 666966
-			mozconfig_add_options_ac '+cpu_flags_arm_neon' \
-				--with-thumb=yes \
-				--with-thumb-interwork=no
-		fi
+	fi
+	
+	if use cpu_flags_arm_thumb && if ! tc-is-clang ; then
+		# thumb options aren't supported when using clang, bug 666966
+		mozconfig_add_options_ac '+cpu_flags_arm_thumb' \
+			--with-thumb=yes \
+			--with-thumb-interwork=no
 	fi
 
 	if [[ ${CHOST} == armv*h* ]] ; then


### PR DESCRIPTION
Right now using clang makes it impossible to allow fpu=neon, but also with gcc thumb needs additional rust-std called thumbv7neon-unknown-linux-gnueabihf. There is still a lot of testing needed to check if it might work to bootstrap that rust-std, but if it does it hasn't worked to detect that additional rust-std at configure when tested last time half a year ago. Situation might have improved, but now known yet. Furthermore, there is not much hope for thumb to ever work with musl, this is it's own can of worms.

This commit should allow it to use clang and fpu=neon, and allows it to turn of thumb for people using musl or those who fail to set up the thumbv7neon-unknown-linux-gnueabihf rust-std

cross compiling with gcc-9 works in all variants